### PR TITLE
🐞 Fix setting fallback mask for ambiguity threshold > 0.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -2,8 +2,8 @@
 name: Pull request
 about: Suggest an idea for this project
 title: ''
-labels: 
-assignees: 
+labels:
+assignees:
 ---
 
 Resolves #ISSUE_NUMBER

--- a/skfb/estimators/_threshold.py
+++ b/skfb/estimators/_threshold.py
@@ -470,7 +470,9 @@ class ThresholdFallbackClassifier(BaseFallbackClassifier):
 
     def _set_fallback_mask(self, y_prob):
         """Sets the fallback mask for predicted probabilites."""
-        y_prob.fallback_mask = y_prob.max(axis=1) < self.threshold
+        y_prob.fallback_mask = _is_top_low(y_prob, self.threshold) | _are_top_2_close(
+            y_prob, self.ambiguity_threshold
+        )
 
 
 def _scoring_path(

--- a/skfb/estimators/_threshold.py
+++ b/skfb/estimators/_threshold.py
@@ -668,7 +668,9 @@ class ThresholdFallbackClassifierCV(ThresholdFallbackClassifier):
 
     def _set_fallback_mask(self, y_prob):
         """Sets the fallback mask for predicted probabilites."""
-        y_prob.fallback_mask = y_prob.max(axis=1) < self.threshold_
+        y_prob.fallback_mask = _is_top_low(y_prob, self.threshold_) | _are_top_2_close(
+            y_prob, self.ambiguity_threshold
+        )
 
 
 def _find_threshold(estimator, X_train, X_test, y_train, fallback_rate):

--- a/skfb/estimators/tests/test_threshold.py
+++ b/skfb/estimators/tests/test_threshold.py
@@ -26,23 +26,25 @@ class TestFallbackEstimator:
 
 
 @pytest.mark.parametrize(
-    "y_score, y_true, threshold, ambiguity_threshold",
+    "y_score, y_true, fb_mask, threshold, ambiguity_threshold",
     [
         (
             np.array([[0.1, 0.2, 0.7], [0.33, 0.33, 0.34], [0.0, 1.0, 0.0]]),
             np.array([-1, -1, 1]),
+            np.array([True, True, False]),
             0.8,
             0.05,
         ),
         (
             np.array([[0.099, 0.4, 0.501], [0.495, 0.4, 0.105], [0.4, 0.5, 0.1]]),
             np.array([2, -1, -1]),
+            np.array([False, True, True]),
             0.2,
             0.1,
         ),
     ],
 )
-def test_predict_or_fallback(y_score, y_true, threshold, ambiguity_threshold):
+def test_predict_or_fallback(y_score, y_true, fb_mask, threshold, ambiguity_threshold):
     """Tests ``predict_or_fallback``."""
     rejector = TestFallbackEstimator()
     rejector.fit()
@@ -56,6 +58,16 @@ def test_predict_or_fallback(y_score, y_true, threshold, ambiguity_threshold):
         ambiguity_threshold=ambiguity_threshold,
     )
     np.testing.assert_array_equal(y_true, y_pred)
+
+    y_pred = predict_or_fallback(
+        rejector,
+        y_score,
+        classes,
+        threshold=threshold,
+        ambiguity_threshold=ambiguity_threshold,
+        fallback_mode="store",
+    )
+    np.testing.assert_array_equal(y_pred.get_dense_fallback_mask(), fb_mask)
 
 
 @pytest.mark.parametrize(
@@ -110,6 +122,12 @@ def test_threshold_fallback_classifier(y_true, y_comb, fallback_label):
     np.testing.assert_array_equal(
         rejector.set_params(fallback_mode="return").predict(X),
         y_comb,
+    )
+
+    rejector.set_params(fallback_mode="store", threshold=0.5, ambiguity_threshold=0.2)
+    np.testing.assert_array_equal(
+        rejector.predict_proba(X).get_dense_fallback_mask(),
+        np.array([False, False, False, False, True, True]),
     )
 
 

--- a/skfb/estimators/tests/test_threshold.py
+++ b/skfb/estimators/tests/test_threshold.py
@@ -195,6 +195,13 @@ def test_threshold_fallback_classifier_cv(y_true, y_comb, fallback_label):
         y_comb,
     )
 
+    rejector.thresold_ = 0.5  # Of course, don't do this in prod...
+    rejector.set_params(fallback_mode="store", ambiguity_threshold=0.2)
+    np.testing.assert_array_equal(
+        rejector.predict_proba(X).get_dense_fallback_mask(),
+        np.array([False, False, False, False, True, True]),
+    )
+
 
 @pytest.mark.parametrize(
     "y_true, y_comb, fallback_label",


### PR DESCRIPTION
Resolves #2 

- [x] Fixes `_set_fallback_mask` for `ThresholdFallbackClassifier` and `ThresholdFallbackClassifierCV`
- [x] Add the corresponding tests.
- [x] Fix the pull-request template format.