### PR TITLE
🔧 Support sklearn<=1.2 by ignoring inavailability of private objects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ For more information, see the project's [Wiki](https://github.com/sanjaradylov/s
 ### 🏗 Installation
 `scikit-fallback` requires:
 * Python (>=3.9,< 3.13)
-* scikit-learn (>=1.3)
+* scikit-learn (>=1.0)
 * matplotlib (>=3.0) (optional)
+
+If you already have `scikit-learn` installed and it's `scikit-learn<=1.2`, make sure that `numpy<2.0`
+to prevent incompatibility.
 
 ```bash
 pip install -U scikit-fallback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
     { name = "Sanjar Ad[yi]lov"},
 ]
 dependencies = [
-    "scikit-learn>=1.3",
+    "scikit-learn>=1.0",
 ]
 dynamic = ["version"]
 

--- a/skfb/__init__.py
+++ b/skfb/__init__.py
@@ -12,4 +12,4 @@ __all__ = (
     "metrics",
 )
 
-__version__ = "0.0.1"
+__version__ = "0.1.0dev0"

--- a/skfb/core/array.py
+++ b/skfb/core/array.py
@@ -9,9 +9,7 @@ import numpy as np
 
 from scipy.sparse import coo_array
 
-# pylint: disable=import-error,no-name-in-module
-# pyright: reportMissingModuleSource=false
-from sklearn.utils._param_validation import validate_params
+from ..utils._legacy import validate_params
 
 
 class FBNDArray(np.ndarray):

--- a/skfb/estimators/_multi_threshold.py
+++ b/skfb/estimators/_multi_threshold.py
@@ -23,12 +23,12 @@ from sklearn.utils._param_validation import (
     Interval,
     Real,
     StrOptions,
-    validate_params,
 )
 
 from .base import BaseFallbackClassifier
 from ..core import array as ska
 from ..metrics._classification import get_scoring
+from ..utils._legacy import validate_params
 
 
 def _is_top_low(y_score, thresholds):

--- a/skfb/estimators/_threshold.py
+++ b/skfb/estimators/_threshold.py
@@ -12,7 +12,6 @@ from sklearn.utils._param_validation import (
     Interval,
     Real,
     StrOptions,
-    validate_params,
 )
 from sklearn.utils.parallel import delayed, Parallel
 from sklearn.utils.validation import check_is_fitted, NotFittedError
@@ -22,6 +21,7 @@ import numpy as np
 from .base import BaseFallbackClassifier
 from ..core import array as ska
 from ..metrics._classification import get_scoring
+from ..utils._legacy import validate_params
 
 
 def _top_2(scores):

--- a/skfb/estimators/base.py
+++ b/skfb/estimators/base.py
@@ -9,15 +9,13 @@ __all__ = (
 import abc
 import warnings
 
-# pylint: disable=no-name-in-module
-# pyright: reportAttributeAccessIssue=false
-from sklearn.base import _fit_context, BaseEstimator, MetaEstimatorMixin
+from sklearn.base import BaseEstimator, MetaEstimatorMixin
 from sklearn.base import clone
 from sklearn.metrics import accuracy_score
 
 # pylint: disable=import-error,no-name-in-module
 # pyright: reportMissingModuleSource=false
-from sklearn.utils._param_validation import HasMethods, validate_params
+from sklearn.utils._param_validation import HasMethods
 from sklearn.utils.metaestimators import available_if
 from sklearn.utils.multiclass import unique_labels
 from sklearn.utils.validation import check_X_y, check_is_fitted
@@ -25,6 +23,7 @@ from sklearn.utils.validation import check_X_y, check_is_fitted
 import numpy as np
 
 from ..core import array as ska
+from ..utils._legacy import _fit_context, validate_params
 
 
 class RejectorMixin:

--- a/skfb/metrics/_classification.py
+++ b/skfb/metrics/_classification.py
@@ -19,13 +19,14 @@ from sklearn.metrics import (
 
 # pylint: disable=import-error,no-name-in-module
 # pyright: reportMissingModuleSource=false
-from sklearn.utils._param_validation import StrOptions, validate_params
+from sklearn.utils._param_validation import StrOptions
 from sklearn.utils import check_consistent_length, column_or_1d
 from sklearn.utils.multiclass import type_of_target
 
 import numpy as np
 
 from ..core import array as ska
+from ..utils._legacy import validate_params
 from ._common import prediction_quality
 
 

--- a/skfb/metrics/_common.py
+++ b/skfb/metrics/_common.py
@@ -2,13 +2,10 @@
 
 import warnings
 
-# pylint: disable=import-error,no-name-in-module
-# pyright: reportMissingModuleSource=false
-from sklearn.utils._param_validation import validate_params
-
 import numpy as np
 
 from ..core import array as ska
+from ..utils._legacy import validate_params
 
 
 @validate_params(

--- a/skfb/metrics/_ranking.py
+++ b/skfb/metrics/_ranking.py
@@ -12,7 +12,6 @@ from sklearn.utils import check_array
 # pylint: disable=import-error,no-name-in-module
 # pyright: reportMissingModuleSource=false
 from sklearn.utils._param_validation import (
-    validate_params,
     Interval,
     Real,
     StrOptions,
@@ -20,6 +19,7 @@ from sklearn.utils._param_validation import (
 from sklearn.utils.multiclass import type_of_target
 
 from ..core.array import fbarray
+from ..utils._legacy import validate_params
 from ._common import prediction_quality
 
 

--- a/skfb/utils/_legacy.py
+++ b/skfb/utils/_legacy.py
@@ -1,0 +1,56 @@
+"""Importing utilities of sklearn>=1.3, preventing errors of <1.3"""
+
+__all__ = (
+    "_fit_context",
+    "validate_params",
+)
+
+import functools
+import inspect
+import warnings
+
+try:
+    # pylint: disable=no-name-in-module
+    from sklearn.base import _fit_context
+except ImportError:
+    warnings.warn(
+        "Fit methods within context managers aren't supported for sklearn<=1.2.",
+        category=ImportWarning,
+    )
+
+    # pylint: disable=unused-argument
+    def _fit_context(*, prefer_skip_nested_validation=False):
+        """For sklearn<=1.2, fit methods aren't run within context managers."""
+
+        def decorator(fit_method):
+
+            @functools.wraps(fit_method)
+            def wrapper(estimator, *args, **kwargs):
+                return fit_method(estimator, *args, **kwargs)
+
+            return wrapper
+
+        return decorator
+
+
+# pylint: disable=import-error,no-name-in-module
+from sklearn.utils._param_validation import validate_params as _validate_params
+
+
+if (
+    "prefer_skip_nested_validation"
+    not in inspect.signature(_validate_params).parameters
+):
+    warnings.warn(
+        "Nested parameter validation isn't supported for sklearn<=1.2.",
+        category=ImportWarning,
+    )
+
+    # pylint: disable=unused-argument
+    def validate_params(parameter_constraints, *, prefer_skip_nested_validation):
+        """For sklearn<=1.2, param validation is not nested."""
+        # pylint: disable=missing-kwoa
+        return _validate_params(parameter_constraints)
+
+else:
+    validate_params = _validate_params


### PR DESCRIPTION
Supporting `scikit-learn<=1.2`:
- [x] ignore nested parameter validation for <=1.2;
- [x] ignore fitting within context managers for <=1.2.