### PR TITLE
🐞 Scipy<1.13 returns only 2D COO array.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,15 +15,17 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
+        sklearn-version: ["1.0", "1.1", "1.2", "1.3", "1.4", "1.5"]
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }} and scikit-learn ${{ matrix.sklearn-version }}
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install scikit-learn~=${{ matrix.sklearn-version }}
         python -m pip install -e .
     - name: Run pre-commit hooks
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ target/
 
 # Temporary files
 .temp/
+
+**/.DS_Store

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include LICENSE
+include pyproject.toml
+include README.md
+
+prune examples/
+prune skfb/**/tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ tests = [
     "black>=24.4.0",
     "matplotlib>=3.0",
     "pre-commit>=3.7.0",
-    "pylint>=3.1.0",
+    "pylint~=3.1.0",
     "pytest>=8.0",
 ]
 dev = [

--- a/skfb/__init__.py
+++ b/skfb/__init__.py
@@ -1,5 +1,14 @@
 """scikit-fallback: machine learning with a reject option."""
 
+import sys
+import warnings
+
+
+if not sys.warnoptions:
+    warnings.simplefilter(action="default")
+
+
+# pylint: disable=wrong-import-position
 from . import (
     core,
     estimators,

--- a/skfb/__init__.py
+++ b/skfb/__init__.py
@@ -12,4 +12,4 @@ __all__ = (
     "metrics",
 )
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/skfb/core/array.py
+++ b/skfb/core/array.py
@@ -22,7 +22,7 @@ class FBNDArray(np.ndarray):
     ----------
     predictions : array-like of shape (n_samples,)
         An array of base-estimator predictions.
-    fallback_mask : array-like of shape (n_samples,) or None
+    fallback_mask : array-like of shape (n_samples,) or (1, n_samples), or None
         Array mask indicating whether i-th sample was rejected by a
         fallback meta-estimator. If None, defaults to all-zeros.
         Further stored as sparse arrays by the ``fallback_mask`` property.
@@ -94,11 +94,14 @@ class FBNDArray(np.ndarray):
         return self.fallback_mask.count_nonzero() / len(self)
 
     def get_dense_fallback_mask(self):
-        """Converts ``fallback_mask`` to ndarray."""
-        return self.fallback_mask.toarray()
+        """Converts ``fallback_mask`` to 1D ndarray."""
+        mask = self.fallback_mask.toarray()
+        if mask.ndim == 2:  # For scipy<1.13
+            mask = mask[0]
+        return mask
 
     def get_dense_neg_fallback_mask(self):
-        """Returns negation of ``fallback_mask`` (acceptance mask) as ndarray."""
+        """Returns negation of ``fallback_mask`` (acceptance mask) as 1D ndarray."""
         return ~self.get_dense_fallback_mask()
 
     def as_comb(self, fallback_label=-1):

--- a/skfb/core/tests/test_array.py
+++ b/skfb/core/tests/test_array.py
@@ -57,7 +57,7 @@ def test_successful_fbndarray(predictions, fallback_mask):
 
     y_comb = np.asarray(predictions).copy()
     fallback_mask = np.asarray(fallback_mask, dtype=np.bool_)
-    fallback_label = 3
+    fallback_label = np.asarray(3, dtype=y_pred.dtype)
     y_comb[fallback_mask] = fallback_label
 
     np.testing.assert_array_equal(

--- a/skfb/estimators/_anomaly.py
+++ b/skfb/estimators/_anomaly.py
@@ -3,15 +3,11 @@
 __all__ = ("AnomalyFallbackClassifier",)
 
 import numpy as np
-
-# pylint: disable=import-error,no-name-in-module
-# pyright: reportMissingModuleSource=false
-from sklearn.utils._param_validation import HasMethods
 from sklearn.utils.metaestimators import available_if
 from sklearn.utils.validation import check_is_fitted, NotFittedError
 
 from ..core import array as ska
-from ..utils._legacy import validate_params
+from ..utils._legacy import HasMethods, validate_params
 from .base import BaseFallbackClassifier, _estimator_has
 
 

--- a/skfb/estimators/_anomaly.py
+++ b/skfb/estimators/_anomaly.py
@@ -136,8 +136,8 @@ class AnomalyFallbackClassifier(BaseFallbackClassifier):
     def _predict(self, X):
         """Runs outlier detection and classification.
 
-        Returns both fallbacks and classes if ``self.fallback_mask == 'return'``,
-        or classes w/ fallback mask if ``self.fallback_mask == 'store'``.
+        Returns both fallbacks and classes if ``self.fallback_mode == 'return'``,
+        or classes w/ fallback mask if ``self.fallback_mode == 'store'``.
         """
         y_out = self.outlier_detector_.predict(X)
         fallback_mask = y_out == -1

--- a/skfb/estimators/_multi_threshold.py
+++ b/skfb/estimators/_multi_threshold.py
@@ -5,6 +5,8 @@ __all__ = (
     "MultiThresholdFallbackClassifier",
 )
 
+import warnings
+
 import numpy as np
 
 from scipy.stats import uniform
@@ -12,23 +14,34 @@ from scipy.stats import uniform
 from sklearn.base import clone
 from sklearn.metrics import get_scorer_names
 from sklearn.model_selection import check_cv, ParameterSampler
-from sklearn.utils.parallel import delayed, Parallel
+
+try:
+    from sklearn.utils.parallel import delayed, Parallel
+except ModuleNotFoundError:
+    from joblib import Parallel
+
+    # pylint: disable=ungrouped-imports
+    from sklearn.utils.fixes import delayed
+
+    warnings.warn(
+        "Using ``joblib.Parallel`` for ``MultiTresholdFallbackClassifierCV`` instead "
+        "of ``sklearn.utils.parallel.Parallel``, which was added in sklearn 1.3.",
+        category=ImportWarning,
+    )
+
 from sklearn.utils.validation import check_is_fitted, NotFittedError
 
-# pylint: disable=import-error,no-name-in-module
-# pyright: reportMissingModuleSource=false
-from sklearn.utils._param_validation import (
+from .base import BaseFallbackClassifier
+from ..core import array as ska
+from ..metrics._classification import get_scoring
+from ..utils._legacy import (
     HasMethods,
     Integral,
     Interval,
     Real,
     StrOptions,
+    validate_params,
 )
-
-from .base import BaseFallbackClassifier
-from ..core import array as ska
-from ..metrics._classification import get_scoring
-from ..utils._legacy import validate_params
 
 
 def _is_top_low(y_score, thresholds):

--- a/skfb/estimators/_threshold.py
+++ b/skfb/estimators/_threshold.py
@@ -6,16 +6,21 @@ from sklearn.base import clone
 from sklearn.metrics import get_scorer_names
 from sklearn.model_selection import check_cv
 
-# pylint: disable=import-error,no-name-in-module
-# pyright: reportMissingModuleSource=false
-from sklearn.utils._param_validation import (
-    HasMethods,
-    Integral,
-    Interval,
-    Real,
-    StrOptions,
-)
-from sklearn.utils.parallel import delayed, Parallel
+try:
+    from sklearn.utils.parallel import delayed, Parallel
+except ModuleNotFoundError:
+    from joblib import Parallel
+
+    # pylint: disable=ungrouped-imports
+    from sklearn.utils.fixes import delayed
+
+    warnings.warn(
+        "Using ``joblib.Parallel`` for ``TresholdFallbackClassifierCV`` and "
+        "``RateFallbackClassifierCV`` instead of ``sklearn.utils.parallel.Parallel``, "
+        "which was added in sklearn 1.3.",
+        category=ImportWarning,
+    )
+
 from sklearn.utils.validation import check_is_fitted, NotFittedError
 
 import numpy as np
@@ -23,7 +28,14 @@ import numpy as np
 from .base import BaseFallbackClassifier
 from ..core import array as ska
 from ..metrics._classification import get_scoring
-from ..utils._legacy import validate_params
+from ..utils._legacy import (
+    HasMethods,
+    Integral,
+    Interval,
+    Real,
+    StrOptions,
+    validate_params,
+)
 
 
 def _top_2(scores):

--- a/skfb/estimators/base.py
+++ b/skfb/estimators/base.py
@@ -200,7 +200,7 @@ class BaseFallbackClassifier(
 
         Returns
         -------
-        Depending on ``self.fallback_mask``:
+        Depending on ``self.fallback_mode``:
         * ("return") a numpy ndarray of both predictions and fallbacks, or;
         * ("store")  an fbndarray of predictions storing also fallback mask, or;
         * ("ignore") a numpy ndarray of only estimator's predictions.
@@ -237,7 +237,7 @@ class BaseFallbackClassifier(
             Predicted class probabilities for `X` based on the estimator.
             The order of the classes corresponds to that in the fitted
             attribute :term:`classes_`.
-            If ``self.fallback_mask == "ignore"``, returns an ndarray.
+            If ``self.fallback_mode == "ignore"``, returns an ndarray.
         """
         check_is_fitted(self, attributes="is_fitted_")
 
@@ -300,7 +300,7 @@ class BaseFallbackClassifier(
             Predicted class log-probabilities for `X` based on the estimator.
             The order of the classes corresponds to that in the fitted
             attribute :term:`classes_`.
-            If ``self.fallback_mask == "ignore"``, returns an ndarray.
+            If ``self.fallback_mode == "ignore"``, returns an ndarray.
         """
         y_prob = self.predict_proba(X)
         return np.log(y_prob)

--- a/skfb/estimators/base.py
+++ b/skfb/estimators/base.py
@@ -13,9 +13,6 @@ from sklearn.base import BaseEstimator, MetaEstimatorMixin
 from sklearn.base import clone
 from sklearn.metrics import accuracy_score
 
-# pylint: disable=import-error,no-name-in-module
-# pyright: reportMissingModuleSource=false
-from sklearn.utils._param_validation import HasMethods, StrOptions
 from sklearn.utils.metaestimators import available_if
 from sklearn.utils.multiclass import unique_labels
 from sklearn.utils.validation import check_X_y, check_is_fitted
@@ -23,7 +20,12 @@ from sklearn.utils.validation import check_X_y, check_is_fitted
 import numpy as np
 
 from ..core import array as ska
-from ..utils._legacy import _fit_context, validate_params
+from ..utils._legacy import (
+    _fit_context,
+    HasMethods,
+    StrOptions,
+    validate_params,
+)
 
 
 class RejectorMixin:

--- a/skfb/metrics/_classification.py
+++ b/skfb/metrics/_classification.py
@@ -18,16 +18,18 @@ from sklearn.metrics import (
     zero_one_loss,
 )
 
-# pylint: disable=import-error,no-name-in-module
-# pyright: reportMissingModuleSource=false
-from sklearn.utils._param_validation import Interval, Real, StrOptions
 from sklearn.utils import check_consistent_length, column_or_1d
 from sklearn.utils.multiclass import type_of_target
 
 import numpy as np
 
 from ..core import array as ska
-from ..utils._legacy import validate_params
+from ..utils._legacy import (
+    Interval,
+    Real,
+    StrOptions,
+    validate_params,
+)
 from ._common import prediction_quality
 
 
@@ -55,7 +57,7 @@ def predict_accept_confusion_matrix(
     y_true : array-like of shape (n_samples,)
         Ground truth (correct) target values.
 
-    y_pred : array-like of shape (n_samples,)
+    y_pred : FBNDArray of shape (n_samples,)
         Estimated targets as returned by both a rejector and a classifier.
 
     labels : array-like of shape (2,), default=None

--- a/skfb/metrics/_ranking.py
+++ b/skfb/metrics/_ranking.py
@@ -9,17 +9,15 @@ from sklearn.metrics import accuracy_score, auc
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import check_array
 
-# pylint: disable=import-error,no-name-in-module
-# pyright: reportMissingModuleSource=false
-from sklearn.utils._param_validation import (
-    Interval,
-    Real,
-    StrOptions,
-)
 from sklearn.utils.multiclass import type_of_target
 
 from ..core.array import fbarray
-from ..utils._legacy import validate_params
+from ..utils._legacy import (
+    Interval,
+    Real,
+    StrOptions,
+    validate_params,
+)
 from ._common import prediction_quality
 
 

--- a/skfb/metrics/tests/test_classification.py
+++ b/skfb/metrics/tests/test_classification.py
@@ -80,7 +80,8 @@ def test_successful_predict_accept_confusion_matrix(y_true, y_pred, cm_true):
     ],
 )
 def test_failed_predict_accept_confusion_matrix(y_true, y_pred):
-    with pytest.raises(ValueError):
+    # ??? AttributeError - for sklearn<1.2, ValueError - otherwise.
+    with pytest.raises((AttributeError, ValueError)):
         predict_accept_confusion_matrix(y_true, y_pred)
 
 

--- a/skfb/utils/_legacy.py
+++ b/skfb/utils/_legacy.py
@@ -1,4 +1,10 @@
-"""Importing utilities of sklearn>=1.3, preventing errors of <1.3"""
+"""Importing utilities of sklearn>=1.2, preventing errors of <1.2.
+
+NOTE: Dynamically creating private sklearn objects absent in older sklearn versions.
+      This could be prevented with reimplementation of private sklearn validators
+      but everything works fine for older sklearn versions - dummy validators are
+      created and validation is ignored.
+"""
 
 __all__ = (
     "_fit_context",
@@ -7,8 +13,11 @@ __all__ = (
 
 import functools
 import inspect
+import sys
 import warnings
 
+
+# region Try importing ``_fit_context``
 try:
     # pylint: disable=no-name-in-module
     from sklearn.base import _fit_context
@@ -23,9 +32,11 @@ except ImportError:
         """For sklearn<=1.2, fit methods aren't run within context managers."""
 
         def decorator(fit_method):
+            """Simply returns wrapped method of estimator."""
 
             @functools.wraps(fit_method)
             def wrapper(estimator, *args, **kwargs):
+                """Simply calls the method."""
                 return fit_method(estimator, *args, **kwargs)
 
             return wrapper
@@ -33,24 +44,81 @@ except ImportError:
         return decorator
 
 
-# pylint: disable=import-error,no-name-in-module
-from sklearn.utils._param_validation import validate_params as _validate_params
+# endregion
 
+# region Try importing parameter validation
+dummy_constraints = (
+    "HasMethods",
+    "Integral",
+    "Interval",
+    "Real",
+    "StrOptions",
+)
 
-if (
-    "prefer_skip_nested_validation"
-    not in inspect.signature(_validate_params).parameters
-):
+try:
+    # pylint: disable=unused-import
+    from sklearn.utils._param_validation import (
+        HasMethods,
+        Integral,
+        Interval,
+        Real,
+        StrOptions,
+        validate_params,
+    )
+
+    # pylint: disable=import-error,no-name-in-module
+    from sklearn.utils._param_validation import validate_params as _validate_params
+
+    if (
+        "prefer_skip_nested_validation"
+        not in inspect.signature(_validate_params).parameters
+    ):
+        warnings.warn(
+            "Nested parameter validation isn't supported for sklearn<=1.2.",
+            category=ImportWarning,
+        )
+
+        # pylint: disable=function-redefined,unused-argument
+        def validate_params(parameter_constraints, *, prefer_skip_nested_validation):
+            """For sklearn<=1.2, param validation is not nested."""
+            # pylint: disable=missing-kwoa
+            return _validate_params(parameter_constraints)
+
+    else:
+        validate_params = _validate_params
+
+except ModuleNotFoundError:
     warnings.warn(
-        "Nested parameter validation isn't supported for sklearn<=1.2.",
+        "Parameter validation isn't supported for sklearn<1.2",
         category=ImportWarning,
     )
 
-    # pylint: disable=unused-argument
-    def validate_params(parameter_constraints, *, prefer_skip_nested_validation):
-        """For sklearn<=1.2, param validation is not nested."""
-        # pylint: disable=missing-kwoa
-        return _validate_params(parameter_constraints)
+    class _Constraint:
+        def __init__(self, *args, **kwargs):
+            pass
 
-else:
-    validate_params = _validate_params
+    module = sys.modules[__name__]
+
+    for constraint in dummy_constraints:
+        Class = type(constraint, (_Constraint,), {"__slots__": ()})
+        setattr(module, constraint, Class)
+
+    # pylint: disable=unused-argument
+    def validate_params(parameter_constraints, **validation_kw):
+        """For sklearn<1.2, parameter validation isn't defined."""
+
+        def decorator(function):
+            """Simply returns wrapped function."""
+
+            @functools.wraps(function)
+            def wrapper(*args, **kwargs):
+                """Simply calls the function."""
+                return function(*args, **kwargs)
+
+            return wrapper
+
+        return decorator
+
+finally:
+    __all__ += dummy_constraints
+# endregion


### PR DESCRIPTION
- [x] For older versions of `scipy` creating only 2D sparse arrays, `fallback_mask` is stored also in 2D but dense arrays are transformed into 1D.
- [x] Fix docstrings.
- [x] Fix pylint version.