### PR TITLE
🐞 Indexing errors in 'estimators'.

### DIFF
--- a/skfb/__init__.py
+++ b/skfb/__init__.py
@@ -23,4 +23,4 @@ __all__ = (
     "metrics",
 )
 
-__version__ = "0.2.0.post0"
+__version__ = "0.2.0.post1"

--- a/skfb/estimators/base.py
+++ b/skfb/estimators/base.py
@@ -81,9 +81,9 @@ class BaseFallbackClassifier(
 ):
     """An ABC for fallback meta-classifiers.
 
-    Upon inheritance, you should reimplement methods `_predict` and
-    `_set_fallback_mask` to make predictions and mask acceptend/rejected inputs,
-    respectively. See, e.g., :class:`~skfb.estimators.ThresholdFallbackCassifier`.
+    Upon inheritance, you should reimplement methods ``_predict`` and
+    ``_set_fallback_mask`` to make predictions and mask accepted/rejected inputs,
+    respectively. See, e.g., :class:`~skfb.estimators.ThresholdFallbackClassifier`.
 
     Parameters
     ----------
@@ -93,11 +93,15 @@ class BaseFallbackClassifier(
         The label of a rejected example.
         Should be compatible w/ the class labels from training data.
     fallback_mode : {"return", "store", "ignore"}, default="store"
-        While predicting, whether to return:
+        While predicting w/ the `predict` method, whether to return:
 
         * (``"return"``) a numpy ndarray of both predictions and fallbacks;
-        * (``"store"``)  an FBNDArray of predictions storing also fallback mask;
+        * (``"store"``)  an ``FBNDArray`` of predictions storing also fallback mask;
         * (``"ignore"``) a numpy ndarray of only estimator's predictions.
+
+        Calling ``decision_function`` or ``predict_proba`` is equivalent to
+        ``estimator``'s corresponding calls except that with ``"store"``, ``FBNDArray``
+        is returned.
     """
 
     _parameter_constraints = {
@@ -333,15 +337,18 @@ class BaseFallbackClassifier(
         Returns
         -------
         score : float
-            Depending on ``self.fallback_mode``:
+            Depending on ``self.fallback_mode``, calculate:
 
-            * (``"return"``) a numpy ndarray of both predictions and fallbacks;
-            * (``"store"``)  an FBNDArray of predictions storing also fallback mask;
-            * (``"ignore"``) a numpy ndarray of only estimator's predictions.
+            * (``"return"``) accuracy on accepted inputs;
+            * (``"store"``)  :func:`~skfb.metrics.predict_reject_accuracy_score`;
+            * (``"ignore"``) accuracy on all inputs.
 
         See also
         --------
-        skfb.metrics.predict_reject_accuracy_score
+        skfb.metrics.predict_reject_accuracy_score : Combined, prediction-rejection
+            accuracy score.
+        skfb.metrics.predict_reject_recall_score : Combined, prediction-rejection
+            balanced accuracy score.
         """
         # ??? Is it the right way to overcome circular imports?
         # pylint: disable=import-outside-toplevel

--- a/skfb/utils/__init__.py
+++ b/skfb/utils/__init__.py
@@ -1,0 +1,5 @@
+"""The :mod:`skfb.utils` module includes validation tools."""
+
+__all__ = ("check_X_y_sample_weight",)
+
+from ._validation import check_X_y_sample_weight

--- a/skfb/utils/_validation.py
+++ b/skfb/utils/_validation.py
@@ -1,0 +1,74 @@
+"""Array validation utilities (mainly for indexing support)."""
+
+from sklearn.base import check_array
+from sklearn.utils import check_X_y
+
+
+def check_X_y_sample_weight(X, y=None, sample_weight=None):
+    """Validation of input data for unified indexing."""
+    if y is not None:
+        try:
+            X, y = check_X_y(
+                X,
+                y,
+                accept_sparse=True,
+                accept_large_sparse=True,
+                dtype=None,
+                order=None,
+                copy=False,
+                ensure_all_finite=False,
+                ensure_2d=False,
+                allow_nd=True,
+            )
+        except TypeError:
+            # `ensure_all_finite` is in place of `force_all_finite`
+            X, y = check_X_y(
+                X,
+                y,
+                accept_sparse=True,
+                accept_large_sparse=True,
+                dtype=None,
+                order=None,
+                copy=False,
+                force_all_finite=False,
+                ensure_2d=False,
+                allow_nd=True,
+            )
+    else:
+        try:
+            X = check_array(
+                X,
+                accept_sparse=True,
+                accept_large_sparse=True,
+                dtype=None,
+                order=None,
+                copy=False,
+                ensure_all_finite=False,
+                ensure_2d=False,
+                allow_nd=True,
+            )
+        except TypeError:
+            # `ensure_all_finite` is in place of `force_all_finite`
+            X = check_array(
+                X,
+                accept_sparse=True,
+                accept_large_sparse=True,
+                dtype=None,
+                order=None,
+                copy=False,
+                force_all_finite=False,
+                ensure_2d=False,
+                allow_nd=True,
+            )
+
+    if sample_weight is not None:
+        sample_weight = check_array(
+            sample_weight,
+            accept_sparse=False,
+            ensure_2d=False,
+            dtype=None,
+            order="C",
+            copy=False,
+        )
+
+    return X, y, sample_weight


### PR DESCRIPTION
## Summary

Some `skfb.estimators` requiring array chunking (such as for cross-validation) throw indexing errors as a result of different access protocols for different 1D and 2D arrays.

## Changes

- [x] `skfb.utils` have a new `check_X_y_sample_weight` to coerce inputs into a unified ndarray. This will further support indexing and other methods required by these estimators.
- [x] `skfb.estimators.RateFallbackClassifierCV` and `skfb.estimators.AnomalyFallbackClassifier` use this validation function.
- [x] Both support sample weights.
- [x] Better documentation.

---

Resolves #33 