### PR TITLE
✨ Introduce utility-coverage and oracle curves / scores.

### DIFF
--- a/docs/source/estimators.rst
+++ b/docs/source/estimators.rst
@@ -22,7 +22,7 @@ thresholds.
 .. autoclass:: skfb.estimators.MultiThresholdFallbackClassifier
     :inherited-members: fit, predict, predict_proba, predict_log_proba, decision_function
 
-.. autoclass:: skfb.estimators.RateFallbackClassifierCV
+.. autoclass:: skfb.estimators.CoverageFallbackClassifierCV
     :inherited-members: fit, predict, predict_proba, predict_log_proba, decision_function
 
 .. autoclass:: skfb.estimators.RuleClassifier

--- a/examples/plot_rejected_samples.py
+++ b/examples/plot_rejected_samples.py
@@ -1,14 +1,14 @@
 """
-==========================================================================
-Learning to reject ambiguously labeled samples w/ RateFallbackClassifierCV
-==========================================================================
+==============================================================================
+Learning to reject ambiguously labeled samples w/ CoverageFallbackClassifierCV
+==============================================================================
 """
 
 from sklearn.datasets import make_blobs
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 
-from skfb.estimators import RateFallbackClassifierCV
+from skfb.estimators import CoverageFallbackClassifierCV
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -34,7 +34,7 @@ X_train, X_test, y_train, y_test, in_mask_train, in_mask_test = train_test_split
 
 # region Train a rejector
 estimator = LogisticRegression(C=10_000, random_state=0)
-rejector = RateFallbackClassifierCV(estimator, fallback_rate=1 / 3, cv=3)
+rejector = CoverageFallbackClassifierCV(estimator, coverage=2 / 3, cv=3)
 rejector.fit(X_train, y_train)
 # endregion
 

--- a/skfb/estimators/__init__.py
+++ b/skfb/estimators/__init__.py
@@ -4,12 +4,14 @@ __all__ = (
     "multi_threshold_predict_or_fallback",
     "predict_or_fallback",
     "AnomalyFallbackClassifier",
+    "CoverageFallbackClassifierCV",
     "FallbackRuleClassifier",
     "MultiThresholdFallbackClassifier",
     "RateFallbackClassifierCV",
     "RuleClassifier",
     "ThresholdFallbackClassifier",
     "ThresholdFallbackClassifierCV",
+    "UtilityFallbackClassifierCV",
 )
 
 from ._anomaly import AnomalyFallbackClassifier
@@ -23,7 +25,9 @@ from ._rule import FallbackRuleClassifier, RuleClassifier
 
 from ._threshold import (
     predict_or_fallback,
+    CoverageFallbackClassifierCV,
     RateFallbackClassifierCV,
     ThresholdFallbackClassifier,
     ThresholdFallbackClassifierCV,
+    UtilityFallbackClassifierCV,
 )

--- a/skfb/estimators/_threshold.py
+++ b/skfb/estimators/_threshold.py
@@ -16,7 +16,7 @@ except ModuleNotFoundError:
 
     warnings.warn(
         "Using ``joblib.Parallel`` for ``ThresholdFallbackClassifierCV`` and "
-        "``RateFallbackClassifierCV`` instead of ``sklearn.utils.parallel.Parallel``, "
+        "``CoverageFallbackClassifierCV`` instead of ``sklearn.utils.parallel.Parallel``, "
         "which was added in sklearn 1.3.",
         category=ImportWarning,
     )
@@ -27,6 +27,7 @@ import numpy as np
 
 from .base import BaseFallbackClassifier
 from ..core import array as ska
+from ..core.exceptions import SKFBWarning
 from ..metrics._classification import get_scoring
 from ..utils._legacy import (
     HasMethods,
@@ -37,6 +38,10 @@ from ..utils._legacy import (
     validate_params,
 )
 from ..utils._validation import check_X_y_sample_weight
+
+
+class UtilityConfigWarning(SKFBWarning):
+    """Raised when no score meets ``min_utility`` in ``UtilityFallbackClassifierCV``."""
 
 
 def _top_2(scores):
@@ -525,18 +530,18 @@ def _find_threshold(estimator, X_train, X_test, y_train, sw_train, fallback_rate
     return np.quantile(y_prob, fallback_rate)
 
 
-class RateFallbackClassifierCV(BaseFallbackClassifier):
-    r"""Fallback classifier learning a threshold based on the desired fallback rate.
+class CoverageFallbackClassifierCV(BaseFallbackClassifier):
+    r"""Fallback classifier learning a threshold from a desired coverage level.
 
-    Let :math:`r` denote the requested fallback rate. For each cross-validation
-    fold, the base estimator is fitted on the training split and the maximum
-    class probabilities :math:`p_{\max}(x)` are computed on the validation
-    split. The per-fold threshold is the empirical :math:`r`-quantile of those
-    values:
+    Let :math:`\varphi` denote the requested coverage (fraction of accepted
+    samples). For each cross-validation fold, the base estimator is fitted on
+    the training split and the maximum class probabilities
+    :math:`p_{\max}(x)` are computed on the validation split. The per-fold
+    threshold is the empirical :math:`(1-\varphi)`-quantile of those values:
 
     .. math::
 
-        t_{\text{fold}} = Q_r\{p_{\max}(x) : x\in \text{fold}\}.
+        t_{\text{fold}} = Q_{1-\varphi}\{p_{\max}(x) : x\in \text{fold}\}.
 
     The learned threshold is the average across folds:
 
@@ -555,8 +560,8 @@ class RateFallbackClassifierCV(BaseFallbackClassifier):
     ----------
     estimator : object
         The base estimator supporting probabilistic predictions.
-    fallback_rate : float, default=0.1
-        The rate of rejected test samples.
+    coverage : float, default=0.9
+        The desired fraction of accepted (non-rejected) test samples.
     cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
@@ -574,6 +579,182 @@ class RateFallbackClassifierCV(BaseFallbackClassifier):
         The label of a rejected example.
         Should be compatible w/ the class labels from training data.
     fallback_mode : {"return", "store"}, default="store"
+        While predicting w/ the ``predict`` method, whether to return:
+
+        * (``"return"``) a numpy ndarray of both predictions and fallbacks;
+        * (``"store"``)  an ``FBNDArray`` of predictions storing also fallback mask;
+        * (``"ignore"``) a numpy ndarray of only estimator's predictions.
+
+        Calling ``decision_function`` or ``predict_proba`` is equivalent to
+        ``estimator``'s corresponding calls except that with ``"store"``, ``FBNDArray``
+        is returned.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.linear_model import LogisticRegression
+    >>> from skfb.estimators import CoverageFallbackClassifierCV
+    >>> estimator = LogisticRegression(random_state=0)
+    >>> X_accept = [[0, 0], [6, 6], [0, 1], [5, 6], [1, 1], [5, 5], [1, 0], [6, 5]]
+    >>> X_ambiguous = [[3.25, 3], [3., 3.25]]
+    >>> X = np.array(X_accept + X_ambiguous)
+    >>> y = np.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+    >>> rejector = CoverageFallbackClassifierCV(
+    ...     estimator,
+    ...     coverage=0.8,
+    ...     cv=2,
+    ...     fallback_label=-1,
+    ...     fallback_mode="return")
+    >>> rejector.fit(X, y).score(X, y)  # Both ambiguous samples were rejected.
+    1.0
+    >>> rejector.set_params(fallback_mode="store").score(X, y)
+    0.9
+
+    See also
+    --------
+    skfb.estimators.ThresholdFallbackClassifier : Fallback classification based on
+        fixed threshold.
+    """
+
+    _parameter_constraints = {**BaseFallbackClassifier._parameter_constraints}
+    _parameter_constraints.update(
+        {
+            "coverage": [Interval(Real, 0.0, 1.0, closed="both")],
+            "cv": ["cv_object"],
+            "scoring": [callable, None],
+            "n_jobs": [Interval(Integral, -1, None, closed="left"), None],
+        },
+    )
+
+    def __init__(
+        self,
+        estimator,
+        *,
+        coverage=0.9,
+        cv=None,
+        n_jobs=None,
+        verbose=0,
+        fallback_label=-1,
+        fallback_mode="store",
+    ):
+        super().__init__(
+            estimator,
+            fallback_label=fallback_label,
+            fallback_mode=fallback_mode,
+        )
+
+        self.coverage = coverage
+        self.cv = cv
+        self.n_jobs = n_jobs
+        self.verbose = verbose
+
+    def _fit(self, X, y, set_attributes=None, **fit_params):
+        """Learns the best threshold."""
+        X, y, sample_weight = check_X_y_sample_weight(
+            X,
+            y=y,
+            sample_weight=fit_params.get("sample_weight"),
+        )
+
+        set_attributes = set_attributes or {}
+
+        cv_ = check_cv(self.cv, y=y, classifier=True)
+
+        estimator = clone(self.estimator)
+
+        thresholds_ = Parallel(
+            n_jobs=self.n_jobs, verbose=self.verbose, prefer="processes"
+        )(
+            delayed(_find_threshold)(
+                estimator,
+                X[train_idx],
+                X[test_idx],
+                y[train_idx],
+                None if sample_weight is None else sample_weight[train_idx],
+                1 - self.coverage,
+            )
+            for train_idx, test_idx in cv_.split(X, y)
+        )
+
+        set_attributes.update(
+            {
+                "cv_": cv_,
+                "thresholds_": np.array(thresholds_),
+                "threshold_": np.mean(thresholds_),
+            },
+        )
+        set_attributes.update(super()._fit(X, y, set_attributes, **fit_params))
+
+        return set_attributes
+
+    def _predict(self, X):
+        """Predicts classes based on the learned certainty threshold."""
+        return predict_or_fallback(
+            self.estimator_,
+            X,
+            self.classes_,
+            threshold=self.threshold_,
+            fallback_label=self.fallback_label_,
+            fallback_mode=self.fallback_mode,
+        )
+
+    def _set_fallback_mask(self, y_prob, X=None):
+        """Sets the fallback mask for predicted probabilites."""
+        y_prob.fallback_mask = y_prob.max(axis=1) < self.threshold_
+
+
+class RateFallbackClassifierCV(CoverageFallbackClassifierCV):
+    r"""Fallback classifier learning a threshold from a desired fallback rate.
+
+    Let :math:`r` denote the requested fallback rate (fraction of rejected
+    samples). For each cross-validation fold, the base estimator is fitted on
+    the training split and the maximum class probabilities
+    :math:`p_{\max}(x)` are computed on the validation split. The per-fold
+    threshold is the empirical :math:`r`-quantile of those values:
+
+    .. math::
+
+        t_{\text{fold}} = Q_r\{p_{\max}(x) : x\in \text{fold}\}.
+
+    The learned threshold is the average across folds:
+
+    .. math::
+
+        t^{\ast} = \frac{1}{n_{\text{folds}}}
+            \sum_{\text{fold}} t_{\text{fold}}.
+
+    The selected average is stored in ``threshold_``. All per-fold thresholds
+    are in ``thresholds_``.
+
+    Predictions then follow the same rule as :class:`ThresholdFallbackClassifier`
+    using ``threshold_``.
+
+    Parameters
+    ----------
+    estimator : object
+        The base estimator supporting probabilistic predictions.
+    fallback_rate : float, default=0.1
+        The desired fraction of rejected test samples. Internally converted to
+        ``coverage = 1 - fallback_rate``.
+    cv : int, cross-validation generator or an iterable, default=None
+        Determines the cross-validation splitting strategy.
+        Possible inputs for cv are:
+
+        - None, to use the efficient Leave-One-Out cross-validation
+        - integer, to specify the number of folds.
+        - :term:`CV splitter`,
+        - An iterable yielding (train, test) splits as arrays of indices.
+
+        For integer/None inputs, if ``y`` is binary or multiclass,
+        :class:`~sklearn.model_selection.StratifiedKFold` is used.
+    n_jobs : int, default=None
+        Number of parallel jobs.
+    verbose : int, default=0
+        Verbosity level.
+    fallback_label : any, default=-1
+        The label of a rejected example.
+        Should be compatible w/ the class labels from training data.
+    fallback_mode : {"return", "store", "ignore"}, default="store"
         While predicting w/ the ``predict`` method, whether to return:
 
         * (``"return"``) a numpy ndarray of both predictions and fallbacks;
@@ -607,19 +788,11 @@ class RateFallbackClassifierCV(BaseFallbackClassifier):
 
     See also
     --------
+    skfb.estimators.CoverageFallbackClassifierCV : Equivalent formulation using
+        coverage (= 1 - fallback_rate) instead.
     skfb.estimators.ThresholdFallbackClassifier : Fallback classification based on
         fixed threshold.
     """
-
-    _parameter_constraints = {**BaseFallbackClassifier._parameter_constraints}
-    _parameter_constraints.update(
-        {
-            "fallback_rate": [Interval(Real, 0.0, 1.0, closed="both")],
-            "cv": ["cv_object"],
-            "scoring": [callable, None],
-            "n_jobs": [Interval(Integral, -1, None, closed="left"), None],
-        },
-    )
 
     def __init__(
         self,
@@ -634,51 +807,248 @@ class RateFallbackClassifierCV(BaseFallbackClassifier):
     ):
         super().__init__(
             estimator,
+            coverage=1 - fallback_rate,
+            cv=cv,
+            n_jobs=n_jobs,
+            verbose=verbose,
+            fallback_label=fallback_label,
+            fallback_mode=fallback_mode,
+        )
+        self.fallback_rate = fallback_rate
+
+
+class UtilityFallbackClassifierCV(ThresholdFallbackClassifier):
+    r"""A fallback classifier that learns the lowest threshold meeting a utility goal.
+
+    Evaluates a candidate set of thresholds :math:`T` by cross-validation. For
+    each threshold :math:`t\in T`, computes the mean validation utility
+    :math:`\bar u(t)`. Among those satisfying :math:`\bar u(t) \ge u_{\min}`,
+    selects the smallest threshold (highest coverage):
+
+    .. math::
+
+        t^{\ast} = \min\{t\in T : \bar u(t) \ge u_{\min}\}.
+
+    If no threshold meets the constraint, falls back to the threshold with the
+    highest mean utility and issues a warning.
+
+    Parameters
+    ----------
+    estimator : object
+        The base estimator making decisions w/o fallbacks.
+    min_utility : float
+        Minimum acceptable utility (greater is better). The learned threshold
+        will be the lowest one whose mean CV utility is at least this value.
+    thresholds : array-like of shape (n_thresholds,) or int, default=None
+        Candidate fallback thresholds to evaluate. If None, defaults to 10
+        thresholds from 1/n_classes to 0.95. If int, generates that many
+        thresholds in the same range.
+    ambiguity_threshold : float, default=0.0
+        Predictions w/ the close top 2 scores are rejected.
+    cv : int, cross-validation generator or an iterable, default=None
+        Determines the cross-validation splitting strategy.
+        Possible inputs for cv are:
+
+        - None, to use the efficient Leave-One-Out cross-validation
+        - integer, to specify the number of folds.
+        - :term:`CV splitter`,
+        - An iterable yielding (train, test) splits as arrays of indices.
+
+        For integer/None inputs, if ``y`` is binary or multiclass,
+        :class:`~sklearn.model_selection.StratifiedKFold` is used.
+    scoring : callable or str, default=None
+        A scorer callable object supporting a reject option, such as metrics from
+        :mod:`~skfb.metrics`.
+        If not from scikit-learn, make sure to wrap it with ``make_scorer``.
+    n_jobs : int, default=None
+        Number of parallel jobs.
+    verbose : int, default=0
+        Verbosity level.
+    fallback_label : any, default=-1
+        The label of a rejected example.
+        Should be compatible w/ the class labels from training data.
+    fallback_mode : {"return", "store", "ignore"}, default="store"
+        While predicting w/ the ``predict`` method, whether to return:
+
+        * (``"return"``) a numpy ndarray of both predictions and fallbacks;
+        * (``"store"``)  an ``FBNDArray`` of predictions storing also fallback mask;
+        * (``"ignore"``) a numpy ndarray of only estimator's predictions.
+
+        Calling ``decision_function`` or ``predict_proba`` is equivalent to
+        ``estimator``'s corresponding calls except that with ``"store"``, ``FBNDArray``
+        is returned.
+
+    Attributes
+    ----------
+    threshold_ : float
+        Learned fallback threshold (lowest meeting ``min_utility``).
+    best_utility_ : float
+        Mean CV utility at the selected threshold.
+    cv_scores_ : ndarray, shape (n_thresholds, n_splits)
+        Trace of CV evaluations.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.linear_model import LogisticRegression
+    >>> from skfb.estimators import UtilityFallbackClassifierCV
+    >>> X = np.array([[0, 0], [4, 4], [1, 1], [3, 3], [2.5, 2], [2., 2.5]])
+    >>> y = np.array([0, 1, 0, 1, 0, 1])
+    >>> estimator = LogisticRegression(random_state=0)
+    >>> rejector = UtilityFallbackClassifierCV(
+    ...     estimator=estimator,
+    ...     min_utility=0.8,
+    ...     thresholds=(0.5, 0.55, 0.6, 0.65),
+    ...     cv=2)
+    >>> rejector.fit(X, y)
+    UtilityFallbackClassifierCV(cv=2,
+                                estimator=LogisticRegression(random_state=0),
+                                min_utility=0.8,
+                                thresholds=(0.5, 0.55, 0.6, 0.65))
+    >>> rejector.threshold_  # Lowest threshold achieving >= 0.8 utility
+    0.55
+
+    See also
+    --------
+    skfb.estimators.ThresholdFallbackClassifier : Fallback classification based on
+        fixed threshold.
+    skfb.estimators.ThresholdFallbackClassifierCV : Learns the best threshold via CV.
+    skfb.estimators.CoverageFallbackClassifierCV : Learns threshold from target
+        coverage.
+    """
+
+    _parameter_constraints = {**ThresholdFallbackClassifier._parameter_constraints}
+    _parameter_constraints.pop("threshold")
+    _parameter_constraints.update(
+        {
+            "min_utility": [Interval(Real, None, None, closed="neither")],
+            "thresholds": ["array-like", int, None],
+            "cv": ["cv_object"],
+            "scoring": [callable, StrOptions(set(get_scorer_names())), None],
+            "n_jobs": [Interval(Integral, -1, None, closed="left"), None],
+        },
+    )
+
+    def __init__(
+        self,
+        estimator,
+        *,
+        min_utility,
+        thresholds=None,
+        ambiguity_threshold=0.0,
+        cv=None,
+        scoring=None,
+        n_jobs=None,
+        verbose=0,
+        fallback_label=-1,
+        fallback_mode="store",
+    ):
+        super().__init__(
+            estimator=estimator,
+            ambiguity_threshold=ambiguity_threshold,
             fallback_label=fallback_label,
             fallback_mode=fallback_mode,
         )
 
-        self.fallback_rate = fallback_rate
+        del self.threshold
+
+        self.min_utility = min_utility
+        self.thresholds = thresholds
         self.cv = cv
+        self.scoring = scoring
         self.n_jobs = n_jobs
         self.verbose = verbose
 
     def _fit(self, X, y, set_attributes=None, **fit_params):
-        """Learns the best threshold."""
-        X, y, sample_weight = check_X_y_sample_weight(
-            X,
-            y=y,
-            sample_weight=fit_params.get("sample_weight"),
-        )
-
+        """Fits the base estimator and finds the lowest threshold meeting min_utility."""
         set_attributes = set_attributes or {}
 
+        # region Maybe create thresholds.
+        if self.thresholds is None or isinstance(self.thresholds, int):
+            classes = set_attributes.get("classes_")
+            n_thresholds = self.thresholds or _N_THRESHOLDS
+            if classes is None:
+                thresholds_ = np.linspace(0.5, 0.95, n_thresholds)
+            else:
+                thresholds_ = np.linspace(1 / len(classes), 0.95, n_thresholds)
+        else:
+            thresholds_ = np.asarray(self.thresholds)
+        # endregion
+
+        # region Validate and/or create objects for cv.
         cv_ = check_cv(self.cv, y=y, classifier=True)
+        # endregion
 
-        estimator = clone(self.estimator)
+        # region Validate and/or create scoring.
+        scoring_ = get_scoring(
+            scoring=self.scoring,
+            fallback_label=set_attributes.get(
+                "fallback_label_",
+                self.fallback_label,
+            ),
+            fallback_mode=self.fallback_mode,
+        )
+        # endregion
 
-        thresholds_ = Parallel(
-            n_jobs=self.n_jobs, verbose=self.verbose, prefer="processes"
-        )(
-            delayed(_find_threshold)(
-                estimator,
+        # region Run maybe parallel scoring paths
+        scores = Parallel(n_jobs=self.n_jobs, verbose=self.verbose, prefer="processes")(
+            delayed(_scoring_path)(
+                self.estimator,
+                threshold,
                 X[train_idx],
                 X[test_idx],
                 y[train_idx],
-                None if sample_weight is None else sample_weight[train_idx],
-                self.fallback_rate,
+                y[test_idx],
+                scoring_,
+                fallback_label=set_attributes.get(
+                    "fallback_label_",
+                    self.fallback_label,
+                ),
+                fallback_mode=self.fallback_mode,
             )
+            for threshold in thresholds_
             for train_idx, test_idx in cv_.split(X, y)
         )
+        cv_scores_ = np.array(scores).reshape(len(thresholds_), cv_.n_splits)
+        # endregion
 
+        # region Select the lowest threshold meeting min_utility
+        mean_cv_scores = cv_scores_.mean(axis=1)
+        feasible_mask = mean_cv_scores >= self.min_utility
+
+        if np.any(feasible_mask):
+            # Among feasible thresholds, pick the lowest (maximizes coverage)
+            feasible_indices = np.where(feasible_mask)[0]
+            best_idx = feasible_indices[np.argmin(thresholds_[feasible_indices])]
+        else:
+            # No threshold meets the constraint; fall back to best utility
+            warnings.warn(
+                f"No threshold achieves min_utility={self.min_utility}; "
+                f"selecting threshold with highest mean CV utility "
+                f"({mean_cv_scores.max():.4f}).",
+                category=UtilityConfigWarning,
+            )
+            best_idx = np.argmax(mean_cv_scores)
+
+        threshold_ = thresholds_[best_idx]
+        best_utility_ = mean_cv_scores[best_idx]
+        # endregion
+
+        # region Update fitted attributes
         set_attributes.update(
             {
+                "thresholds_": thresholds_,
                 "cv_": cv_,
-                "thresholds_": np.array(thresholds_),
-                "threshold_": np.mean(thresholds_),
+                "cv_scores_": cv_scores_,
+                "scoring_": scoring_,
+                "threshold_": threshold_,
+                "best_utility_": best_utility_,
             },
         )
-        set_attributes.update(super()._fit(X, y, set_attributes, **fit_params))
+        set_attributes.update(
+            super()._fit(X, y, set_attributes=set_attributes, **fit_params)
+        )
+        # endregion
 
         return set_attributes
 
@@ -695,4 +1065,6 @@ class RateFallbackClassifierCV(BaseFallbackClassifier):
 
     def _set_fallback_mask(self, y_prob, X=None):
         """Sets the fallback mask for predicted probabilites."""
-        y_prob.fallback_mask = y_prob.max(axis=1) < self.threshold_
+        y_prob.fallback_mask = _is_top_low(y_prob, self.threshold_) | _are_top_2_close(
+            y_prob, self.ambiguity_threshold
+        )

--- a/skfb/estimators/tests/test_threshold.py
+++ b/skfb/estimators/tests/test_threshold.py
@@ -7,9 +7,11 @@ import pytest
 
 from skfb.estimators import (
     predict_or_fallback,
+    CoverageFallbackClassifierCV,
     RateFallbackClassifierCV,
     ThresholdFallbackClassifier,
     ThresholdFallbackClassifierCV,
+    UtilityFallbackClassifierCV,
 )
 
 from .test_common import TestFallbackEstimator
@@ -235,17 +237,17 @@ def test_threshold_fallback_classifier_cv(y_true, y_comb, fallback_label):
         ),
     ],
 )
-def test_rate_fallback_classifier(y_true, y_comb, fallback_label):
-    """Tests fit, predict, and attrs of ``RateFallbackClassifierCV``."""
+def test_coverage_fallback_classifier(y_true, y_comb, fallback_label):
+    """Tests fit, predict, and attrs of ``CoverageFallbackClassifierCV``."""
     X_accept = [[0, 0], [6, 6], [0, 1], [5, 6], [1, 1], [5, 5], [1, 0], [6, 5]]
     X_ambiguous = [[3.25, 3], [3.0, 3.25]]
     X = np.array(X_accept + X_ambiguous)
 
     estimator = LogisticRegression(random_state=0)
-    fallback_rate = 0.2
+    coverage = 0.8
     cv = 2
 
-    rejector = RateFallbackClassifierCV(estimator, fallback_rate=fallback_rate, cv=cv)
+    rejector = CoverageFallbackClassifierCV(estimator, coverage=coverage, cv=cv)
     rejector.set_params(fallback_label=fallback_label).fit(X, y_true)
 
     for key in ["cv_", "estimator_", "threshold_", "thresholds_"]:
@@ -263,3 +265,102 @@ def test_rate_fallback_classifier(y_true, y_comb, fallback_label):
         rejector.set_params(fallback_mode="return").predict(X),
         y_comb,
     )
+
+
+def test_rate_fallback_classifier_cv():
+    """Tests that ``RateFallbackClassifierCV`` produces same results as Coverage."""
+    X_accept = [[0, 0], [6, 6], [0, 1], [5, 6], [1, 1], [5, 5], [1, 0], [6, 5]]
+    X_ambiguous = [[3.25, 3], [3.0, 3.25]]
+    X = np.array(X_accept + X_ambiguous)
+    y = np.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+
+    estimator = LogisticRegression(random_state=0)
+
+    rejector = RateFallbackClassifierCV(estimator, fallback_rate=0.2, cv=2)
+    rejector.fit(X, y)
+    assert hasattr(rejector, "threshold_")
+
+    rejector_new = CoverageFallbackClassifierCV(estimator, coverage=0.8, cv=2)
+    rejector_new.fit(X, y)
+    np.testing.assert_almost_equal(rejector.threshold_, rejector_new.threshold_)
+
+
+@pytest.mark.parametrize(
+    "y_true, fallback_label",
+    [
+        (np.array([0, 1, 0, 1, 0, 1]), -1),
+        (np.array([0, 1, 0, 1, 0, 1]), 2),
+        (np.array(["a", "b", "a", "b", "a", "b"]), "c"),
+    ],
+)
+def test_utility_fallback_classifier_cv(y_true, fallback_label):
+    """Tests fit, predict, and attrs of ``UtilityFallbackClassifierCV``."""
+    X = np.array([[0, 0], [4, 4], [1, 1], [3, 3], [2.5, 2], [2.0, 2.5]])
+
+    estimator = LogisticRegression(random_state=0)
+    thresholds = (0.5, 0.55, 0.6, 0.65, 0.7)
+    cv = 2
+
+    rejector = UtilityFallbackClassifierCV(
+        estimator,
+        min_utility=0.8,
+        thresholds=thresholds,
+        cv=cv,
+        fallback_label=fallback_label,
+        fallback_mode="store",
+    )
+    rejector.fit(X, y_true)
+
+    for key in [
+        "classes_",
+        "fallback_label_",
+        "cv_",
+        "cv_scores_",
+        "scoring_",
+        "threshold_",
+        "best_utility_",
+    ]:
+        assert hasattr(rejector, key)
+
+    np.testing.assert_equal(
+        rejector.fallback_label_.dtype,
+        rejector.classes_.dtype,
+    )
+
+    # The learned threshold must achieve at least min_utility
+    assert rejector.best_utility_ >= 0.8
+
+    # Threshold should be the lowest feasible one
+    mean_scores = rejector.cv_scores_.mean(axis=1)
+    feasible = mean_scores >= 0.8
+    if np.any(feasible):
+        expected_threshold = np.asarray(thresholds)[feasible].min()
+        assert rejector.threshold_ == expected_threshold
+
+    y_pred = rejector.predict(X)
+    assert hasattr(y_pred, "get_dense_fallback_mask")
+
+    # Test with fallback_mode="return"
+    y_return = rejector.set_params(fallback_mode="return").predict(X)
+    assert y_return.dtype == rejector.classes_.dtype
+
+
+def test_utility_fallback_classifier_cv_warning():
+    """Tests that a warning is issued when no threshold meets min_utility."""
+    X = np.array([[0, 0], [4, 4], [1, 1], [3, 3], [2.5, 2], [2.0, 2.5]])
+    y = np.array([0, 1, 0, 1, 0, 1])
+
+    estimator = LogisticRegression(random_state=0)
+
+    rejector = UtilityFallbackClassifierCV(
+        estimator,
+        min_utility=1.0,  # Unreachable utility
+        thresholds=(0.5, 0.6, 0.7),
+        cv=2,
+    )
+
+    with pytest.warns(UserWarning, match="No threshold achieves min_utility"):
+        rejector.fit(X, y)
+
+    # Should still have a valid threshold (falls back to best utility)
+    assert hasattr(rejector, "threshold_")

--- a/skfb/metrics/__init__.py
+++ b/skfb/metrics/__init__.py
@@ -4,21 +4,34 @@ __all__ = (
     "fallback_quality_auc_score",
     "fallback_quality_curve",
     "get_scoring",
+    "oracle_auc_score",
+    "oracle_curve",
+    "oracle_utility_gap_score",
     "predict_accept_confusion_matrix",
     "predict_reject_accuracy_score",
     "predict_reject_recall_score",
     "prediction_quality",
+    "utility_coverage_curve",
     "FQCurveDisplay",
     "PAConfusionMatrixDisplay",
     "PairedHistogramDisplay",
+    "UCCurveDisplay",
 )
 
 from ._classification import (
     get_scoring,
+    oracle_auc_score,
+    oracle_curve,
+    oracle_utility_gap_score,
     predict_accept_confusion_matrix,
     predict_reject_accuracy_score,
     predict_reject_recall_score,
 )
-from ._common import prediction_quality
-from ._plot import FQCurveDisplay, PAConfusionMatrixDisplay, PairedHistogramDisplay
+from ._common import prediction_quality, utility_coverage_curve
+from ._plot import (
+    FQCurveDisplay,
+    PAConfusionMatrixDisplay,
+    PairedHistogramDisplay,
+    UCCurveDisplay,
+)
 from ._ranking import fallback_quality_auc_score, fallback_quality_curve

--- a/skfb/metrics/_classification.py
+++ b/skfb/metrics/_classification.py
@@ -12,6 +12,7 @@ import warnings
 
 from sklearn.metrics import (
     accuracy_score,
+    auc,
     confusion_matrix,
     get_scorer,
     get_scorer_names,
@@ -31,7 +32,7 @@ from ..utils._legacy import (
     StrOptions,
     validate_params,
 )
-from ._common import prediction_quality
+from ._common import prediction_quality, utility_coverage_auc_score
 
 
 @validate_params(
@@ -277,6 +278,199 @@ def predict_reject_recall_score(y_true, y_pred, beta=0.5):
     cm = predict_accept_confusion_matrix(y_true, y_pred)
     ta, tr, fa, fr = cm[1, 1], cm[0, 0], cm[0, 1], cm[1, 0]
     return ta / (ta + fr) * beta + tr / (tr + fa) * (1 - beta)
+
+
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+        "n_bins": [int, None],
+    },
+    prefer_skip_nested_validation=True,
+)
+def oracle_curve(y_true, y_pred, *, n_bins=None):
+    """Computes the oracle curve.
+
+    The oracle curve represents the theoretical best selective accuracy
+    achievable at each coverage level, assuming perfect knowledge of which
+    predictions are correct.
+
+    Suppose the full-coverage accuracy of a model is
+
+    .. math:: a = \\Pr\\{y_{\\text{true}} = y_{\\text{pred}}\\}
+
+    Then the oracle selective accuracy is
+
+    .. math::
+        A^*(a, c) = \\begin{cases}
+            1, & c \\leq a \\\\
+            \\frac{a}{c}, & c > a
+        \\end{cases}
+
+    Parameters
+    ----------
+    y_true : array-like, shape (n_samples,)
+        True labels.
+    y_pred : array-like, shape (n_samples,)
+        Predicted labels.
+    n_bins : int, default=None
+        Number of evenly spaced coverage levels. If None, evaluates at
+        every sample-level coverage (k/n for k=1..n).
+
+    Returns
+    -------
+    utility : ndarray, shape (n_bins,) or (n_samples,)
+        Oracle accuracy values for each coverage level.
+    coverage : ndarray, shape (n_bins,) or (n_samples,)
+        Coverage values.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skfb.metrics._classification import oracle_curve
+    >>> y_true = np.array([0, 1, 1, 0, 1])
+    >>> y_pred = np.array([0, 1, 0, 0, 1])
+    >>> utility, coverage = oracle_curve(y_true, y_pred)
+    >>> utility
+    array([1. , 1. , 1. , 1. , 0.8])
+    >>> coverage
+    array([0.2, 0.4, 0.6, 0.8, 1. ])
+    """
+    y_type, y_true, y_pred = _check_targets(y_true, y_pred)
+
+    y_true = np.asarray(y_true)
+    y_pred = np.asarray(y_pred)
+
+    accuracy = np.mean(y_true == y_pred)
+
+    if n_bins is not None:
+        coverage = np.linspace(1.0 / n_bins, 1.0, n_bins)
+    else:
+        n_samples = len(y_true)
+        coverage = np.arange(1, n_samples + 1) / n_samples
+
+    utility = np.where(coverage <= accuracy, 1.0, accuracy / coverage)
+
+    return utility, coverage
+
+
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+    },
+    prefer_skip_nested_validation=True,
+)
+def oracle_auc_score(y_true, y_pred):
+    """Calculates the area under the oracle curve.
+
+    The oracle curve represents the theoretical best selective accuracy
+    achievable at each coverage level, assuming perfect knowledge of which
+    predictions are correct.
+
+    Parameters
+    ----------
+    y_true : array-like, shape (n_samples,)
+        True labels.
+    y_pred : array-like, shape (n_samples,)
+        Predicted labels.
+
+    Returns
+    -------
+    float : area under the oracle curve
+    """
+    utility, coverage = oracle_curve(y_true, y_pred)
+    return auc(coverage, utility)
+
+
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+        "y_score": ["array-like", None],
+        "scoring": [str, callable],
+        "labels": ["array-like", None],
+        "sample_weight": ["array-like", None],
+    },
+    prefer_skip_nested_validation=True,
+)
+def oracle_utility_gap_score(
+    y_true,
+    y_pred,
+    *,
+    y_score=None,
+    scoring="accuracy",
+    labels=None,
+    sample_weight=None,
+):
+    """Computes the gap between oracle AUC and utility-coverage AUC.
+
+    A lower value indicates the model's selective predictions are closer to
+    the theoretical optimum. A value of 0 means the model achieves oracle-level
+    selective accuracy at every coverage level.
+
+    .. math::
+        \\text{gap} = \\text{AUC}_{\\text{oracle}} - \\text{AUC}_{\\text{utility}}
+
+    Parameters
+    ----------
+    y_true : array-like, shape (n_samples,)
+        True labels.
+    y_pred : array-like, shape (n_samples,) or (n_samples, n_classes)
+        Predicted labels or probability matrix. If 2D and ``y_score`` is None,
+        confidence scores and hard predictions are inferred from this matrix.
+    y_score : array-like, shape (n_samples,), default=None
+        Confidence scores for each prediction. If None, inferred from
+        ``y_pred`` (requires ``y_pred`` to be 2D).
+    scoring : str or callable, default="accuracy"
+        A string (see :ref:`scoring_parameter`) or a scorer callable object /
+        function with signature ``scorer(y_true, y_pred)``.
+    labels : array-like, shape (n_classes,), default=None
+        Class labels ordered by column index in ``y_pred`` when ``y_pred`` is 2D.
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    Returns
+    -------
+    gap : float
+        Difference between oracle AUC and utility-coverage AUC (>= 0).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skfb.metrics import oracle_utility_gap_score
+    >>> y_true = np.array([0, 1, 0, 1, 0])
+    >>> y_proba = np.array([
+    ...     [0.9, 0.1],
+    ...     [0.2, 0.8],
+    ...     [0.7, 0.3],
+    ...     [0.3, 0.7],
+    ...     [0.6, 0.4],
+    ... ])
+    >>> oracle_utility_gap_score(y_true, y_proba)
+    0.0
+    """
+    y_pred_arr = np.asarray(y_pred)
+
+    # Resolve hard predictions for oracle_auc_score
+    if y_pred_arr.ndim == 2:
+        if labels is not None:
+            y_pred_hard = np.asarray(labels)[np.argmax(y_pred_arr, axis=1)]
+        else:
+            y_pred_hard = np.argmax(y_pred_arr, axis=1)
+    else:
+        y_pred_hard = y_pred_arr
+
+    o_auc = oracle_auc_score(y_true, y_pred_hard)
+    uc_auc = utility_coverage_auc_score(
+        y_true,
+        y_pred,
+        y_score=y_score,
+        scoring=scoring,
+        labels=labels,
+        sample_weight=sample_weight,
+    )
+    return o_auc - uc_auc
 
 
 def error_rejection_loss(

--- a/skfb/metrics/_common.py
+++ b/skfb/metrics/_common.py
@@ -3,6 +3,8 @@
 import warnings
 
 import numpy as np
+from sklearn.metrics import auc, get_scorer
+from sklearn.utils import check_consistent_length
 
 from ..core import array as ska
 from ..core.exceptions import SKFBWarning
@@ -67,3 +69,285 @@ def prediction_quality(
         return np.nan
 
     return score_func(y_true[non_rejected_mask], y_pred[non_rejected_mask], **kwargs)
+
+
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+        "y_score": ["array-like", None],
+        "scoring": [str, callable],
+        "n_bins": [int, None],
+        "labels": ["array-like", None],
+        "sample_weight": ["array-like", None],
+    },
+    prefer_skip_nested_validation=True,
+)
+def utility_coverage_curve(
+    y_true,
+    y_pred,
+    *,
+    y_score=None,
+    scoring="accuracy",
+    n_bins=None,
+    labels=None,
+    sample_weight=None,
+):
+    """Returns performance-coverage sequence:
+
+    .. math::
+        \\text{utility}(k) = \\text{scoring}(y_{true}[:k], y_{pred}[:k]),
+        \\text{coverage}(k) = \\frac{k}{n_{samples}}
+
+    where :math:`k` is the number of accepted samples; ``y_true`` and ``y_pred`` are
+    sorted by confidence score in descending order.
+
+    Parameters
+    ----------
+    y_true : array-like, shape (n_samples,)
+        True labels.
+    y_pred : array-like, shape (n_samples,) or (n_samples, n_classes)
+        Predicted labels or probability matrix. If 2D and ``y_score`` is None,
+        confidence scores are inferred as ``np.max(y_pred, axis=1)`` and hard
+        predictions as ``labels[np.argmax(y_pred, axis=1)]`` (or ``np.argmax``
+        if ``labels`` is None).
+    y_score : array-like, shape (n_samples,), default=None
+        Confidence scores for each prediction. If None, inferred from
+        ``y_pred`` (requires ``y_pred`` to be 2D).
+    scoring : callable or str, default="accuracy"
+        Scorer as risk evaluation (e.g., log-loss, accuracy).
+        Can be a scikit-learn scorer name (e.g., "accuracy", "f1") or a callable
+        with signature ``scorer(y_true, y_pred) -> float`` (higher is better).
+    n_bins : int, default=None
+        Number of evenly spaced coverage levels to evaluate at. If None,
+        evaluation happens at each unique score threshold. For example,
+        ``n_bins=10`` evaluates at coverage = 0.1, 0.2, ..., 1.0.
+    labels : array-like, shape (n_classes,), default=None
+        Class labels ordered by column index in ``y_pred`` when ``y_pred`` is 2D.
+        Used to map argmax indices to actual label values.
+    sample_weight : array-like, shape (n_samples,), default=None
+        Sample weights.
+
+    Returns
+    -------
+    utility : ndarray, shape (n_thresholds,)
+        Utility values for each obtained coverage level.
+    coverage : ndarray, shape (n_thresholds,)
+        Coverage values computed at each unique threshold.
+    thresholds : ndarray, shape (n_thresholds,)
+        Unique score thresholds in descending order.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skfb.metrics import utility_coverage_curve
+    >>> y_true = np.array([0, 1, 0, 2, 2, 1, 0, 0, 1, 0])
+    >>> y_proba = np.array([
+    ...     [0.95, 0.03, 0.02],
+    ...     [0.40, 0.35, 0.25],
+    ...     [0.90, 0.05, 0.05],
+    ...     [0.05, 0.85, 0.10],
+    ...     [0.10, 0.10, 0.80],
+    ...     [0.20, 0.60, 0.20],
+    ...     [0.20, 0.20, 0.60],
+    ...     [0.70, 0.20, 0.10],
+    ...     [0.70, 0.20, 0.10],
+    ...     [0.55, 0.25, 0.20],
+    ... ])
+    >>> utility, coverage, thresholds = utility_coverage_curve(y_true, y_proba)
+    >>> utility
+    array([1.0, 1.0, 0.67, 0.75, 0.67, 0.625, 0.67, 0.6])
+    >>> coverage
+    array([0.1, 0.2, 0.3, 0.4, 0.6, 0.8, 0.9, 1.0])
+    >>> thresholds
+    array([0.95, 0.9, 0.85, 0.8, 0.7, 0.6, 0.55, 0.4])
+    """
+    y_true = np.asarray(y_true)
+    y_pred = np.asarray(y_pred)
+
+    # Determine if the scorer expects probabilities rather than hard labels.
+    _needs_proba = False
+    if isinstance(scoring, str):
+        _scorer_tmp = get_scorer(scoring)
+        _resp = getattr(_scorer_tmp, "_response_method", "predict")
+        if isinstance(_resp, str):
+            _needs_proba = _resp == "predict_proba"
+        else:
+            _needs_proba = "predict_proba" in _resp
+
+    if y_score is None:
+        if y_pred.ndim < 2:
+            raise ValueError(
+                "y_score must be provided when y_pred is not a 2D probability matrix."
+            )
+        y_score = np.max(y_pred, axis=1)
+        if not _needs_proba:
+            if labels is not None:
+                labels = np.asarray(labels)
+                y_pred = labels[np.argmax(y_pred, axis=1)]
+            else:
+                y_pred = np.argmax(y_pred, axis=1)
+    else:
+        y_score = np.asarray(y_score)
+
+    check_consistent_length(y_true, y_pred, y_score)
+
+    # Infer all unique class labels from full y_true for scorers that need them
+    # (e.g., log_loss requires knowing all classes even on subsets).
+    all_labels = np.unique(y_true)
+
+    if isinstance(scoring, str):
+        scorer = get_scorer(scoring)
+
+        def _score_fn(y_true_prefix, y_pred_prefix, sample_weight_prefix):
+            kwargs = dict(scorer._kwargs)
+            if sample_weight_prefix is not None:
+                kwargs["sample_weight"] = sample_weight_prefix
+            kwargs.setdefault("labels", all_labels)
+            try:
+                return scorer._sign * scorer._score_func(
+                    y_true_prefix,
+                    y_pred_prefix,
+                    **kwargs,
+                )
+            except TypeError:
+                # Score function doesn't accept `labels`; retry without it.
+                kwargs.pop("labels", None)
+                return scorer._sign * scorer._score_func(
+                    y_true_prefix,
+                    y_pred_prefix,
+                    **kwargs,
+                )
+
+    else:
+
+        def _score_fn(y_true_prefix, y_pred_prefix, sample_weight_prefix):
+            if sample_weight_prefix is None:
+                try:
+                    return scoring(y_true_prefix, y_pred_prefix, labels=all_labels)
+                except TypeError:
+                    return scoring(y_true_prefix, y_pred_prefix)
+            try:
+                return scoring(
+                    y_true_prefix,
+                    y_pred_prefix,
+                    sample_weight=sample_weight_prefix,
+                    labels=all_labels,
+                )
+            except TypeError:
+                try:
+                    return scoring(
+                        y_true_prefix,
+                        y_pred_prefix,
+                        sample_weight=sample_weight_prefix,
+                    )
+                except TypeError:
+                    return scoring(y_true_prefix, y_pred_prefix)
+
+    sorted_indices = np.argsort(y_score, kind="mergesort")[::-1]
+    y_true = y_true[sorted_indices]
+    y_pred = y_pred[sorted_indices]
+    y_score = y_score[sorted_indices]
+
+    if sample_weight is not None:
+        sample_weight = np.asarray(sample_weight)[sorted_indices]
+    else:
+        sample_weight = None
+
+    # Evaluate once per unique threshold so tied confidence scores map to one point.
+    threshold_end_indices = np.r_[
+        np.where(np.diff(y_score) != 0)[0],
+        len(y_score) - 1,
+    ]
+
+    if n_bins is not None:
+        # Evaluate at evenly spaced coverage levels.
+        n_samples = len(y_score)
+        target_coverage = np.linspace(1.0 / n_bins, 1.0, n_bins)
+        target_indices = np.clip(
+            np.ceil(target_coverage * n_samples).astype(int) - 1,
+            0,
+            n_samples - 1,
+        )
+        # Snap each target index forward to the end of its tie group.
+        for i, idx in enumerate(target_indices):
+            # Find the tie group that contains this index.
+            group_mask = threshold_end_indices >= idx
+            if group_mask.any():
+                target_indices[i] = threshold_end_indices[group_mask][0]
+        # Deduplicate while preserving order.
+        _, unique_mask = np.unique(target_indices, return_index=True)
+        target_indices = target_indices[np.sort(unique_mask)]
+        eval_indices = target_indices
+
+    else:
+        eval_indices = threshold_end_indices
+
+    thresholds = y_score[eval_indices]
+    coverage = (eval_indices + 1) / len(y_score)
+
+    utility = np.empty_like(coverage, dtype=float)
+    for i, end_idx in enumerate(eval_indices):
+        upto = end_idx + 1
+        if sample_weight is None:
+            utility[i] = _score_fn(y_true[:upto], y_pred[:upto], None)
+        else:
+            utility[i] = _score_fn(y_true[:upto], y_pred[:upto], sample_weight[:upto])
+
+    return utility, coverage, thresholds
+
+
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+        "y_score": ["array-like", None],
+        "scoring": [str, callable],
+        "labels": ["array-like", None],
+        "sample_weight": ["array-like", None],
+    },
+    prefer_skip_nested_validation=True,
+)
+def utility_coverage_auc_score(
+    y_true,
+    y_pred,
+    *,
+    y_score=None,
+    scoring="accuracy",
+    labels=None,
+    sample_weight=None,
+):
+    """Evaluates area under the utility-coverage curve.
+
+    Parameters
+    ----------
+    y_true : array-like, shape (n_samples,)
+        True labels.
+    y_pred : array-like, shape (n_samples,) or (n_samples, n_classes)
+        Predicted labels or probability matrix. If 2D and ``y_score`` is None,
+        confidence scores and hard predictions are inferred from this matrix.
+    y_score : array-like, shape (n_samples,), default=None
+        Confidence scores for each prediction. If None, inferred from
+        ``y_pred`` (requires ``y_pred`` to be 2D).
+    scoring : str or callable, default="accuracy"
+        A string (see :ref:`scoring_parameter`) or a scorer callable object /
+        function with signature ``scorer(y_true, y_pred)``.
+    labels : array-like, shape (n_classes,), default=None
+        Class labels ordered by column index in ``y_pred`` when ``y_pred`` is 2D.
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    Returns
+    -------
+    auc_score : float
+        Area under the utility-coverage curve.
+    """
+    utility, coverage, _ = utility_coverage_curve(
+        y_true,
+        y_pred,
+        y_score=y_score,
+        scoring=scoring,
+        labels=labels,
+        sample_weight=sample_weight,
+    )
+    return auc(coverage, utility)

--- a/skfb/metrics/_plot.py
+++ b/skfb/metrics/_plot.py
@@ -6,7 +6,8 @@ from sklearn.utils import check_consistent_length
 from sklearn.utils.validation import check_is_fitted
 
 from ..estimators.base import is_rejector
-from ._classification import predict_accept_confusion_matrix
+from ._classification import oracle_curve, predict_accept_confusion_matrix
+from ._common import utility_coverage_curve
 from ._ranking import fallback_quality_curve
 
 
@@ -647,3 +648,318 @@ class PairedHistogramDisplay:
 
         viz = cls(score_true, score_false)
         return viz.plot(ax=ax, cumulative=cumulative)
+
+
+class UCCurveDisplay:
+    """Utility-Coverage Curve visualization with optional oracle reference.
+
+    Plots the utility-coverage curve and optionally the oracle curve to visualize
+    how close a model's selective predictions are to the theoretical optimum.
+    The oracle curve is only meaningful when the utility metric is accuracy.
+
+    It is recommended to use
+    :func:`~skfb.metrics.UCCurveDisplay.from_estimator` or
+    :func:`~skfb.metrics.UCCurveDisplay.from_predictions` to create
+    a :class:`UCCurveDisplay`. All parameters are stored as attributes.
+
+    Parameters
+    ----------
+    utility : array-like
+        Utility values at each coverage level.
+    coverage : array-like
+        Coverage values for the utility-coverage curve.
+    oracle_utility : array-like, default=None
+        Oracle utility values at each coverage level. If None, oracle is not plotted.
+    oracle_coverage : array-like, default=None
+        Coverage values for the oracle curve. If None, oracle is not plotted.
+    uc_auc : float, default=None
+        Area under the utility-coverage curve.
+    oracle_auc : float, default=None
+        Area under the oracle curve.
+    estimator_name : str, default=None
+        Name of the estimator.
+    utility_name : str, default=None
+        Name of the utility metric.
+
+    Attributes
+    ----------
+    line_ : matplotlib Artist
+        Utility-coverage curve line.
+    oracle_line_ : matplotlib Artist
+        Oracle curve line.
+    ax_ : matplotlib Axes
+        Axes with the curves.
+    figure_ : matplotlib Figure
+        Figure containing the curves.
+
+    See Also
+    --------
+    skfb.metrics.utility_coverage_curve
+    skfb.metrics.oracle_curve
+    skfb.metrics.oracle_utility_gap_score
+    """
+
+    def __init__(
+        self,
+        *,
+        utility,
+        coverage,
+        oracle_utility=None,
+        oracle_coverage=None,
+        uc_auc=None,
+        oracle_auc=None,
+        estimator_name=None,
+        utility_name=None,
+    ):
+        self.utility = utility
+        self.coverage = coverage
+        self.oracle_utility = oracle_utility
+        self.oracle_coverage = oracle_coverage
+        self.uc_auc = uc_auc
+        self.oracle_auc = oracle_auc
+        self.estimator_name = estimator_name
+        self.utility_name = utility_name
+
+    def plot(self, ax=None, *, line_kwargs=None, oracle_line_kwargs=None):
+        """Plots utility-coverage and oracle curves.
+
+        Parameters
+        ----------
+        ax : matplotlib Axes, default=None
+            Axes object to plot on. If None, a new figure and axes is created.
+        line_kwargs : dict, default=None
+            Additional keyword arguments passed to the utility-coverage line.
+        oracle_line_kwargs : dict, default=None
+            Additional keyword arguments passed to the oracle line.
+
+        Returns
+        -------
+        display : :class:`UCCurveDisplay`
+        """
+        check_matplotlib_support(f"{self.__class__.__name__}.plot")
+
+        import matplotlib.pyplot as plt
+
+        if ax is None:
+            _, self.ax_ = plt.subplots()
+        else:
+            self.ax_ = ax
+        self.figure_ = self.ax_.figure
+
+        # Oracle curve (only if data is available)
+        self.oracle_line_ = None
+        if self.oracle_utility is not None and self.oracle_coverage is not None:
+            oracle_line_kwargs = oracle_line_kwargs or {}
+            oracle_line_kwargs.setdefault("linestyle", "--")
+            oracle_line_kwargs.setdefault("color", "grey")
+            if self.oracle_auc is not None:
+                oracle_line_kwargs.setdefault(
+                    "label", f"Oracle (AUC = {self.oracle_auc:.2f})"
+                )
+            else:
+                oracle_line_kwargs.setdefault("label", "Oracle")
+
+            (self.oracle_line_,) = self.ax_.plot(
+                self.oracle_coverage, self.oracle_utility, **oracle_line_kwargs
+            )
+
+        # Utility-coverage curve
+        line_kwargs = line_kwargs or {}
+        label = self.estimator_name or "Model"
+        if self.uc_auc is not None:
+            label += f" (AUC = {self.uc_auc:.2f})"
+        line_kwargs.setdefault("label", label)
+
+        (self.line_,) = self.ax_.plot(self.coverage, self.utility, **line_kwargs)
+
+        self.ax_.set(
+            xlabel="Coverage",
+            ylabel="Utility" if self.utility_name is None else self.utility_name,
+        )
+        self.ax_.legend()
+        self.ax_.set_title("Utility-Coverage Curve")
+
+        return self
+
+    @classmethod
+    def from_estimator(
+        cls,
+        estimator,
+        X,
+        y,
+        *,
+        scoring="accuracy",
+        n_bins=10,
+        show_oracle="auto",
+        labels=None,
+        sample_weight=None,
+        estimator_name=None,
+        utility_name=None,
+        ax=None,
+        line_kwargs=None,
+        oracle_line_kwargs=None,
+    ):
+        """Creates display from a fitted estimator and data.
+
+        Parameters
+        ----------
+        estimator : estimator instance
+            Fitted classifier with a ``predict_proba`` method.
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            Input values.
+        y : array-like of shape (n_samples,)
+            True labels.
+        scoring : str or callable, default="accuracy"
+            Scoring function for utility evaluation.
+        n_bins : int, default=10
+            Number of evenly spaced coverage levels to evaluate at.
+        show_oracle : bool or "auto", default="auto"
+            Whether to plot the oracle curve. If "auto", shows the oracle
+            only when ``scoring="accuracy"``.
+        labels : array-like, default=None
+            Class labels ordered by column index in probability matrix.
+        sample_weight : array-like of shape (n_samples,), default=None
+            Sample weights.
+        estimator_name : str, default=None
+            Name of the estimator for the legend.
+        utility_name : str, default=None
+            Name of the utility metric for the y-axis label.
+        ax : matplotlib Axes, default=None
+            Axes object to plot on.
+        line_kwargs : dict, default=None
+            Keyword arguments for the utility-coverage line.
+        oracle_line_kwargs : dict, default=None
+            Keyword arguments for the oracle line.
+
+        Returns
+        -------
+        display : :class:`UCCurveDisplay`
+        """
+        check_matplotlib_support(f"{cls.__name__}.from_estimator")
+        check_is_fitted(estimator)
+
+        estimator_name = estimator_name or estimator.__class__.__name__
+        y_prob = estimator.predict_proba(X)
+
+        return cls.from_predictions(
+            y,
+            y_prob,
+            scoring=scoring,
+            n_bins=n_bins,
+            show_oracle=show_oracle,
+            labels=labels,
+            sample_weight=sample_weight,
+            estimator_name=estimator_name,
+            utility_name=utility_name,
+            ax=ax,
+            line_kwargs=line_kwargs,
+            oracle_line_kwargs=oracle_line_kwargs,
+        )
+
+    @classmethod
+    def from_predictions(
+        cls,
+        y_true,
+        y_pred,
+        *,
+        y_score=None,
+        scoring="accuracy",
+        n_bins=10,
+        show_oracle="auto",
+        labels=None,
+        sample_weight=None,
+        estimator_name=None,
+        utility_name=None,
+        ax=None,
+        line_kwargs=None,
+        oracle_line_kwargs=None,
+    ):
+        """Creates display from true labels and predictions.
+
+        Parameters
+        ----------
+        y_true : array-like of shape (n_samples,)
+            True labels.
+        y_pred : array-like of shape (n_samples,) or (n_samples, n_classes)
+            Predicted labels or probability matrix.
+        y_score : array-like of shape (n_samples,), default=None
+            Confidence scores. If None, inferred from 2D ``y_pred``.
+        scoring : str or callable, default="accuracy"
+            Scoring function for utility evaluation.
+        n_bins : int, default=10
+            Number of evenly spaced coverage levels to evaluate at.
+        show_oracle : bool or "auto", default="auto"
+            Whether to plot the oracle curve. If "auto", shows the oracle
+            only when ``scoring="accuracy"``.
+        labels : array-like, default=None
+            Class labels ordered by column index in probability matrix.
+        sample_weight : array-like of shape (n_samples,), default=None
+            Sample weights.
+        estimator_name : str, default=None
+            Name of the estimator for the legend.
+        utility_name : str, default=None
+            Name of the utility metric for the y-axis label.
+        ax : matplotlib Axes, default=None
+            Axes object to plot on.
+        line_kwargs : dict, default=None
+            Keyword arguments for the utility-coverage line.
+        oracle_line_kwargs : dict, default=None
+            Keyword arguments for the oracle line.
+
+        Returns
+        -------
+        display : :class:`UCCurveDisplay`
+        """
+        check_matplotlib_support(f"{cls.__name__}.from_predictions")
+
+        import numpy as np
+
+        # Resolve whether to show oracle
+        if show_oracle == "auto":
+            show_oracle = scoring == "accuracy"
+
+        y_pred_arr = np.asarray(y_pred)
+
+        # Compute utility-coverage curve
+        utility, coverage, _ = utility_coverage_curve(
+            y_true,
+            y_pred,
+            y_score=y_score,
+            scoring=scoring,
+            n_bins=n_bins,
+            labels=labels,
+            sample_weight=sample_weight,
+        )
+        uc_auc_val = auc(coverage, utility)
+
+        # Compute oracle curve only when applicable
+        o_utility = None
+        o_coverage = None
+        oracle_auc_val = None
+        if show_oracle:
+            if y_pred_arr.ndim == 2:
+                if labels is not None:
+                    y_pred_hard = np.asarray(labels)[np.argmax(y_pred_arr, axis=1)]
+                else:
+                    y_pred_hard = np.argmax(y_pred_arr, axis=1)
+            else:
+                y_pred_hard = y_pred_arr
+
+            o_utility, o_coverage = oracle_curve(y_true, y_pred_hard, n_bins=n_bins)
+            oracle_auc_val = auc(o_coverage, o_utility)
+
+        viz = cls(
+            utility=utility,
+            coverage=coverage,
+            oracle_utility=o_utility,
+            oracle_coverage=o_coverage,
+            uc_auc=uc_auc_val,
+            oracle_auc=oracle_auc_val,
+            estimator_name=estimator_name,
+            utility_name=utility_name,
+        )
+        return viz.plot(
+            ax=ax,
+            line_kwargs=line_kwargs,
+            oracle_line_kwargs=oracle_line_kwargs,
+        )

--- a/skfb/metrics/tests/test_classification.py
+++ b/skfb/metrics/tests/test_classification.py
@@ -10,6 +10,7 @@ from skfb.core import array as ska
 from skfb.experimental import enable_error_rejection_loss  # noqa: F401
 from skfb.metrics import (
     error_rejection_loss,
+    oracle_curve,
     predict_accept_confusion_matrix,
     predict_reject_accuracy_score,
     predict_reject_recall_score,
@@ -149,6 +150,18 @@ def test_predict_reject_accuracy_score(y_true, y_pred, result):
 )
 def test_predict_reject_recall_score(y_true, y_pred, beta, result):
     assert predict_reject_recall_score(y_true, y_pred, beta=beta) == result
+
+
+def test_oracle_curve():
+    """Tests that the oracle curve is correctly computed."""
+    y_true = np.array([0, 1, 1, 0, 1, 0, 1, 0, 0, 0])
+    y_pred = np.array([0, 1, 0, 0, 1, 0, 0, 1, 0, 1])
+    utility, coverage = oracle_curve(y_true, y_pred)
+    np.testing.assert_almost_equal(
+        utility,
+        np.array([1.0] * 6 + [6 / 7, 6 / 8, 6 / 9, 6 / 10]),
+    )
+    np.testing.assert_almost_equal(coverage, np.linspace(0.1, 1.0, 10))
 
 
 @pytest.mark.parametrize(

--- a/skfb/metrics/tests/test_common.py
+++ b/skfb/metrics/tests/test_common.py
@@ -5,7 +5,7 @@ import pytest
 
 from sklearn.metrics import accuracy_score, f1_score
 
-from skfb.metrics import prediction_quality
+from skfb.metrics import prediction_quality, utility_coverage_curve
 
 
 @pytest.mark.parametrize(
@@ -32,3 +32,106 @@ def test_nonempty_prediction_quality_score(score_func, result):
         )
         == result
     )
+
+
+@pytest.mark.parametrize(
+    "sample_weight, true_utility",
+    [
+        (None, np.array([1 / 2, 3 / 4, 3 / 5])),
+        (np.ones(5), np.array([1 / 2, 3 / 4, 3 / 5])),
+        (
+            np.arange(1, 6),
+            np.array(
+                [
+                    1 * 1 / (1 * 1 + 1 * 2),
+                    (1 * 1 + 1 * 3 + 1 * 4) / (1 * 1 + 1 * 2 + 1 * 3 + 1 * 4),
+                    (1 * 1 + 1 * 3 + 1 * 4) / (1 * 1 + 1 * 2 + 1 * 3 + 1 * 4 + 1 * 5),
+                ],
+            ),
+        ),
+    ],
+)
+def test_utility_coverage_curve(sample_weight, true_utility):
+    """Sample weights are propagated while evaluating each threshold prefix."""
+    y_true = np.array([1, 0, 1, 0, 1])
+    y_pred = np.array([1, 1, 1, 0, 0])
+    y_score = np.array([0.9, 0.9, 0.7, 0.7, 0.1])
+
+    utility, coverage, thresholds = utility_coverage_curve(
+        y_true,
+        y_pred,
+        y_score=y_score,
+        scoring=accuracy_score,
+        sample_weight=sample_weight,
+    )
+
+    np.testing.assert_allclose(utility, true_utility)
+    np.testing.assert_allclose(coverage, np.array([0.4, 0.8, 1.0]))
+    np.testing.assert_allclose(thresholds, np.array([0.9, 0.7, 0.1]))
+
+
+def test_utility_coverage_curve_infer_from_2d():
+    """When y_score is None and y_pred is 2D, scores and labels are inferred."""
+    y_true = np.array([0, 1, 0, 2, 2, 1, 0, 0, 1, 0])
+    y_proba = np.array(
+        [
+            [0.95, 0.03, 0.02],
+            [0.40, 0.35, 0.25],
+            [0.90, 0.05, 0.05],
+            [0.05, 0.85, 0.10],
+            [0.10, 0.10, 0.80],
+            [0.20, 0.60, 0.20],
+            [0.20, 0.20, 0.60],
+            [0.70, 0.20, 0.10],
+            [0.70, 0.20, 0.10],
+            [0.55, 0.25, 0.20],
+        ]
+    )
+
+    # Explicit y_score path
+    y_pred = np.argmax(y_proba, axis=1)
+    y_score = np.max(y_proba, axis=1)
+    u_explicit, c_explicit, t_explicit = utility_coverage_curve(
+        y_true, y_pred, y_score=y_score
+    )
+
+    # Inferred path (2D y_pred, no y_score)
+    u_inferred, c_inferred, t_inferred = utility_coverage_curve(y_true, y_proba)
+
+    np.testing.assert_allclose(u_inferred, u_explicit)
+    np.testing.assert_allclose(c_inferred, c_explicit)
+    np.testing.assert_allclose(t_inferred, t_explicit)
+
+
+def test_utility_coverage_curve_infer_with_string_labels():
+    """String labels are mapped correctly via the labels parameter."""
+    y_true = np.array(["cat", "dog", "cat", "bird"])
+    y_proba = np.array(
+        [
+            [0.9, 0.05, 0.05],
+            [0.1, 0.8, 0.1],
+            [0.7, 0.2, 0.1],
+            [0.1, 0.1, 0.8],
+        ]
+    )
+    labels = np.array(["cat", "dog", "bird"])
+
+    utility, coverage, thresholds = utility_coverage_curve(
+        y_true, y_proba, labels=labels
+    )
+
+    # Scores: [0.9, 0.8, 0.7, 0.8] → sorted: [0.9, 0.8, 0.8, 0.7]
+    # Unique thresholds: 0.9 (end idx 0), 0.8 (end idx 2), 0.7 (end idx 3)
+    np.testing.assert_allclose(thresholds, np.array([0.9, 0.8, 0.7]))
+    np.testing.assert_allclose(coverage, np.array([0.25, 0.75, 1.0]))
+    # All predictions match y_true at every coverage level
+    np.testing.assert_allclose(utility, np.array([1.0, 1.0, 1.0]))
+
+
+def test_utility_coverage_curve_raises_without_score_and_1d():
+    """ValueError raised when y_pred is 1D and y_score is not given."""
+    y_true = np.array([0, 1, 0])
+    y_pred = np.array([0, 1, 1])
+
+    with pytest.raises(ValueError, match="y_score must be provided"):
+        utility_coverage_curve(y_true, y_pred)


### PR DESCRIPTION
# Summary

Introduces utilities to create, summarize, and plot utility-(risk, accuracy, log-loss, etc.)-coverage curves and optionally compare them to the oracle curves.

# Details

- [x] `skfb.metrics.utility_coverage_curve` to calculate *utility* scores (e.g., accuracy) for each given or default coverage level:
  ```python

    >>> import numpy as np
    >>> from skfb.metrics import utility_coverage_curve
    >>> y_true = np.array([0, 1, 0, 2, 2, 1, 0, 0, 1, 0])
    >>> y_proba = np.array([
    ...     [0.95, 0.03, 0.02],
    ...     [0.40, 0.35, 0.25],
    ...     [0.90, 0.05, 0.05],
    ...     [0.05, 0.85, 0.10],
    ...     [0.10, 0.10, 0.80],
    ...     [0.20, 0.60, 0.20],
    ...     [0.20, 0.20, 0.60],
    ...     [0.70, 0.20, 0.10],
    ...     [0.70, 0.20, 0.10],
    ...     [0.55, 0.25, 0.20],
    ... ])
    >>> utility, coverage, thresholds = utility_coverage_curve(y_true, y_proba)
    >>> utility
    array([1.0, 1.0, 0.67, 0.75, 0.67, 0.625, 0.67, 0.6])
    >>> coverage
    array([0.1, 0.2, 0.3, 0.4, 0.6, 0.8, 0.9, 1.0])
    >>> thresholds
    array([0.95, 0.9, 0.85, 0.8, 0.7, 0.6, 0.55, 0.4])
  ```
- [x] `skfb.metrics.utility_coverage_auc_score` to calculate the area under utility-coverage curve.
- [x] `skfb.metrics.oracle_curve` to calculate the oracle curve.
- [x] `skfb.metrics.oracle_auc_score` to summarize the oracle curve.
- [x] `skfb.metrics.oracle_utility_gap_score` to calculate the gap between the oracle curve and estimator accuracy at each coverage level.

---

Maybe resolves #27 